### PR TITLE
Implement appointment tools and agent with unit tests

### DIFF
--- a/app/agents/appointments_agent/agent.py
+++ b/app/agents/appointments_agent/agent.py
@@ -1,1 +1,65 @@
-# placeholder: orquesta herramientas de Calendar
+"""Agent that orchestrates calendar, messaging and state tools for appointments."""
+from strands import Agent, tool
+
+from ...tools import (
+    google_calendar_tool,
+    messaging_tool,
+    notify_owner_tool,
+    scheduler_tool,
+    state_store,
+)
+
+
+@tool
+def crear_cita(
+    paciente: str,
+    telefono: str,
+    inicio_iso: str,
+    fin_iso: str,
+    descripcion: str = "",
+) -> str:
+    """Create a new appointment and schedule reminders."""
+    event = google_calendar_tool.crear_evento(
+        paciente, inicio_iso, fin_iso, descripcion
+    )
+    state_store.save_state(
+        event["id"],
+        {"paciente": paciente, "telefono": telefono, "inicio": inicio_iso, "fin": fin_iso},
+    )
+    scheduler_tool.schedule_reminders(event["id"], inicio_iso)
+    messaging_tool.send_whatsapp(
+        telefono, f"Tu cita ha sido programada para {inicio_iso}."
+    )
+    notify_owner_tool.notify_owner(
+        f"Nueva cita de {paciente} el {inicio_iso}"
+    )
+    return event["id"]
+
+
+@tool
+def actualizar_cita(evento_id: str, inicio_iso: str, fin_iso: str) -> str:
+    """Update an existing appointment."""
+    google_calendar_tool.actualizar_evento(
+        evento_id, start={"dateTime": inicio_iso}, end={"dateTime": fin_iso}
+    )
+    state_store.save_state(evento_id, {"inicio": inicio_iso, "fin": fin_iso})
+    scheduler_tool.schedule_reminders(evento_id, inicio_iso)
+    return evento_id
+
+
+@tool
+def cancelar_cita(evento_id: str, telefono: str) -> str:
+    """Cancel an appointment."""
+    google_calendar_tool.eliminar_evento(evento_id)
+    state_store.delete_state(evento_id)
+    messaging_tool.send_whatsapp(telefono, "Tu cita ha sido cancelada.")
+    notify_owner_tool.notify_owner(f"Cita cancelada {evento_id}")
+    return evento_id
+
+
+appointments_agent = Agent(
+    system_prompt=(
+        "Eres el asistente de Pelvis Therapy para gestionar citas. "
+        "Usa las herramientas disponibles para crear, actualizar o cancelar citas."),
+    tools=[crear_cita, actualizar_cita, cancelar_cita],
+)

--- a/app/tools/google_calendar_tool.py
+++ b/app/tools/google_calendar_tool.py
@@ -1,1 +1,30 @@
-# placeholder: create/update/delete events con google-api-python-client
+"""Wrappers around Google Calendar client functions exposed as tools."""
+from strands import tool
+from . import gcal_client
+
+
+@tool
+def crear_evento(
+    resumen: str,
+    inicio_iso: str,
+    fin_iso: str,
+    descripcion: str,
+    correo_asistente: str | None = None,
+) -> dict:
+    """Create an event in Google Calendar."""
+    return gcal_client.create_event(
+        resumen, inicio_iso, fin_iso, descripcion, correo_asistente
+    )
+
+
+@tool
+def actualizar_evento(evento_id: str, **fields) -> dict:
+    """Update an existing Google Calendar event."""
+    return gcal_client.update_event(evento_id, **fields)
+
+
+@tool
+def eliminar_evento(evento_id: str) -> str:
+    """Delete an event from Google Calendar."""
+    gcal_client.delete_event(evento_id)
+    return evento_id

--- a/app/tools/messaging_tool.py
+++ b/app/tools/messaging_tool.py
@@ -1,1 +1,21 @@
-# placeholder: envío WhatsApp via AWS End User Messaging Social (boto3 client social-messaging)
+"""Send WhatsApp or SMS messages using AWS clients."""
+import boto3
+from strands import tool
+
+
+@tool
+def send_whatsapp(to_e164: str, mensaje: str) -> dict:
+    """Send a WhatsApp message using the AWS social-messaging client."""
+    client = boto3.client("social-messaging")
+    return client.send_whatsapp_message(
+        DestinationPhoneNumber=to_e164,
+        MessageBody=mensaje,
+    )
+
+
+@tool
+def send_sms(to_e164: str, mensaje: str) -> dict:
+    """Send an SMS using Amazon SNS."""
+    client = boto3.client("sns")
+    resp = client.publish(PhoneNumber=to_e164, Message=mensaje)
+    return {"MessageId": resp.get("MessageId")}

--- a/app/tools/notify_owner_tool.py
+++ b/app/tools/notify_owner_tool.py
@@ -1,1 +1,13 @@
-# placeholder: SMS via SNS
+"""Notify the clinic owner via SMS using SNS."""
+import os
+import boto3
+from strands import tool
+
+OWNER_PHONE = os.environ.get("OWNER_PHONE", "")
+
+
+@tool
+def notify_owner(mensaje: str, telefono: str = OWNER_PHONE) -> dict:
+    """Send an SMS message to the owner."""
+    client = boto3.client("sns")
+    return client.publish(PhoneNumber=telefono, Message=mensaje)

--- a/app/tools/scheduler_tool.py
+++ b/app/tools/scheduler_tool.py
@@ -1,1 +1,36 @@
-# placeholder: crea schedules one-time en EventBridge Scheduler (24h y +4h)
+"""Create one-time reminder schedules in EventBridge Scheduler."""
+import json
+import os
+from datetime import timedelta
+
+import boto3
+from dateutil import parser as dtparser
+from strands import tool
+
+TARGET_ARN = os.environ.get("REMINDER_TARGET_ARN", "")
+ROLE_ARN = os.environ.get("REMINDER_ROLE_ARN", "")
+GROUP_NAME = os.environ.get("REMINDER_GROUP", "default")
+
+
+@tool
+def schedule_reminders(evento_id: str, inicio_iso: str) -> dict:
+    """Create schedules 24h and 4h before the appointment."""
+    client = boto3.client("scheduler")
+    start = dtparser.isoparse(inicio_iso)
+    results = {}
+    for hours in (24, 4):
+        run = start - timedelta(hours=hours)
+        name = f"{evento_id}-{hours}h"
+        resp = client.create_schedule(
+            Name=name,
+            GroupName=GROUP_NAME,
+            ScheduleExpression=f"at({run.strftime('%Y-%m-%dT%H:%M:%S')})",
+            FlexibleTimeWindow={"Mode": "OFF"},
+            Target={
+                "Arn": TARGET_ARN,
+                "RoleArn": ROLE_ARN,
+                "Input": json.dumps({"event_id": evento_id, "offset_hours": hours}),
+            },
+        )
+        results[name] = resp
+    return results

--- a/app/tools/state_store.py
+++ b/app/tools/state_store.py
@@ -1,1 +1,35 @@
-# placeholder: CRUD en DynamoDB para estado conversación y confirmaciones
+"""Simple DynamoDB based state storage."""
+import os
+import boto3
+from strands import tool
+
+TABLE_NAME = os.environ.get("STATE_TABLE", "appointments_state")
+_table_cache = None
+
+
+def _table():
+    global _table_cache
+    if _table_cache is None:
+        _table_cache = boto3.resource("dynamodb").Table(TABLE_NAME)
+    return _table_cache
+
+
+@tool
+def save_state(clave: str, datos: dict) -> None:
+    """Persist conversation state in DynamoDB."""
+    item = {"id": clave}
+    item.update(datos)
+    _table().put_item(Item=item)
+
+
+@tool
+def get_state(clave: str) -> dict | None:
+    """Retrieve conversation state."""
+    resp = _table().get_item(Key={"id": clave})
+    return resp.get("Item")
+
+
+@tool
+def delete_state(clave: str) -> None:
+    """Delete conversation state."""
+    _table().delete_item(Key={"id": clave})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_appointments_agent.py
+++ b/tests/test_appointments_agent.py
@@ -1,0 +1,30 @@
+from app.agents.appointments_agent import agent as ag
+
+
+def test_crear_cita_orquesta(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(
+        ag.google_calendar_tool, "crear_evento", lambda *a, **k: {"id": "evt"}
+    )
+
+    def save_state(*a, **k):
+        calls["state"] = (a, k)
+
+    def sched(*a, **k):
+        calls["sched"] = (a, k)
+
+    def wa(*a, **k):
+        calls["wa"] = (a, k)
+
+    def owner(*a, **k):
+        calls["owner"] = (a, k)
+
+    monkeypatch.setattr(ag.state_store, "save_state", save_state)
+    monkeypatch.setattr(ag.scheduler_tool, "schedule_reminders", sched)
+    monkeypatch.setattr(ag.messaging_tool, "send_whatsapp", wa)
+    monkeypatch.setattr(ag.notify_owner_tool, "notify_owner", owner)
+
+    eid = ag.crear_cita("Ana", "+593", "2024-01-02T10:00:00", "2024-01-02T11:00:00")
+    assert eid == "evt"
+    assert set(calls.keys()) == {"state", "sched", "wa", "owner"}

--- a/tests/test_google_calendar_tool.py
+++ b/tests/test_google_calendar_tool.py
@@ -1,0 +1,40 @@
+from app.tools import google_calendar_tool as gtool
+
+
+def test_crear_evento_invoca_cliente(monkeypatch):
+    llamado = {}
+
+    def fake_create(summary, start, end, desc, attendee):
+        llamado["args"] = (summary, start, end, desc, attendee)
+        return {"id": "1"}
+
+    monkeypatch.setattr(gtool.gcal_client, "create_event", fake_create)
+    res = gtool.crear_evento("s", "a", "b", "d", "e")
+    assert res["id"] == "1"
+    assert llamado["args"] == ("s", "a", "b", "d", "e")
+
+
+def test_actualizar_evento(monkeypatch):
+    llamado = {}
+
+    def fake_update(eid, **fields):
+        llamado["eid"] = eid
+        llamado["fields"] = fields
+        return {"id": eid}
+
+    monkeypatch.setattr(gtool.gcal_client, "update_event", fake_update)
+    res = gtool.actualizar_evento("abc", foo=1)
+    assert res["id"] == "abc"
+    assert llamado == {"eid": "abc", "fields": {"foo": 1}}
+
+
+def test_eliminar_evento(monkeypatch):
+    llamado = {}
+
+    def fake_delete(eid):
+        llamado["eid"] = eid
+
+    monkeypatch.setattr(gtool.gcal_client, "delete_event", fake_delete)
+    eid = gtool.eliminar_evento("xyz")
+    assert llamado["eid"] == "xyz"
+    assert eid == "xyz"

--- a/tests/test_messaging_tool.py
+++ b/tests/test_messaging_tool.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from app.tools import messaging_tool
+
+
+def test_send_whatsapp(monkeypatch):
+    calls = {}
+
+    class Client:
+        def send_whatsapp_message(self, **kwargs):
+            calls.update(kwargs)
+            return {"MessageId": "1"}
+
+    monkeypatch.setattr(
+        messaging_tool, "boto3", SimpleNamespace(client=lambda name: Client())
+    )
+    messaging_tool.send_whatsapp("+593", "hola")
+    assert calls["DestinationPhoneNumber"] == "+593"
+    assert calls["MessageBody"] == "hola"
+
+
+def test_send_sms(monkeypatch):
+    calls = {}
+
+    class SNSClient:
+        def publish(self, **kwargs):
+            calls.update(kwargs)
+            return {"MessageId": "abc"}
+
+    monkeypatch.setattr(
+        messaging_tool, "boto3", SimpleNamespace(client=lambda name: SNSClient())
+    )
+    resp = messaging_tool.send_sms("+593", "hi")
+    assert calls["PhoneNumber"] == "+593"
+    assert resp["MessageId"] == "abc"

--- a/tests/test_notify_owner_tool.py
+++ b/tests/test_notify_owner_tool.py
@@ -1,0 +1,19 @@
+from types import SimpleNamespace
+
+from app.tools import notify_owner_tool
+
+
+def test_notify_owner(monkeypatch):
+    calls = {}
+
+    class SNSClient:
+        def publish(self, **kwargs):
+            calls.update(kwargs)
+            return {"MessageId": "1"}
+
+    monkeypatch.setattr(
+        notify_owner_tool, "boto3", SimpleNamespace(client=lambda name: SNSClient())
+    )
+    notify_owner_tool.notify_owner("hola", "+593")
+    assert calls["PhoneNumber"] == "+593"
+    assert calls["Message"] == "hola"

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+from app.tools import scheduler_tool
+
+
+def test_schedule_reminders(monkeypatch):
+    calls = []
+
+    class Client:
+        def create_schedule(self, **kwargs):
+            calls.append(kwargs)
+            return {"Name": kwargs["Name"]}
+
+    monkeypatch.setattr(
+        scheduler_tool, "boto3", SimpleNamespace(client=lambda name: Client())
+    )
+    scheduler_tool.schedule_reminders("ev1", "2024-01-02T10:00:00")
+    assert len(calls) == 2
+    names = {c["Name"] for c in calls}
+    assert "ev1-24h" in names and "ev1-4h" in names

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,26 @@
+from app.tools import state_store
+
+
+def test_state_store_crud(monkeypatch):
+    class Table:
+        def __init__(self):
+            self.items = {}
+
+        def put_item(self, Item):
+            self.items[Item["id"]] = Item
+
+        def get_item(self, Key):
+            return {"Item": self.items.get(Key["id"])}
+
+        def delete_item(self, Key):
+            self.items.pop(Key["id"], None)
+
+    tbl = Table()
+    monkeypatch.setattr(state_store, "_table", lambda: tbl)
+
+    state_store.save_state("1", {"foo": "bar"})
+    assert tbl.items["1"]["foo"] == "bar"
+    item = state_store.get_state("1")
+    assert item == {"id": "1", "foo": "bar"}
+    state_store.delete_state("1")
+    assert "1" not in tbl.items


### PR DESCRIPTION
## Summary
- Add Google Calendar helper tools
- Implement messaging, scheduling, state persistence, and owner notification utilities
- Build appointments agent orchestrating calendar, messaging, and persistence
- Cover new tools with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9fc9e87083229c2ff68950ec9638