### PR TITLE
Improve DynamoDB error handling

### DIFF
--- a/app/runtime/reminder_scheduler.py
+++ b/app/runtime/reminder_scheduler.py
@@ -105,8 +105,8 @@ def handler(event, context):
         appt_dt = dt.datetime.fromisoformat(appt_iso.replace("Z", "+00:00")).astimezone(
             dt.timezone.utc
         )
-    except Exception:
-        logger.exception("Invalid appt_time_iso: %s", appt_iso)
+    except ValueError as e:
+        logger.exception("Invalid appt_time_iso %s: %s", appt_iso, e)
         raise
 
     # Tiempos (modo normal vs. modo rápido de pruebas)

--- a/app/tools/whatsapp_owner.py
+++ b/app/tools/whatsapp_owner.py
@@ -46,13 +46,13 @@ def _post_messages(payload: dict) -> dict:
             logger.info("WA resp: %s", txt)
             try:
                 return {"ok": True, "resp": json.loads(txt)}
-            except Exception:
+            except json.JSONDecodeError:
                 return {"ok": True, "resp_text": txt}
     except urllib.error.HTTPError as e:
         err = e.read().decode("utf-8") if e.fp else str(e)
         logger.error("WA error %s: %s", e.code, err)
         return {"ok": False, "status": e.code, "error": err}
-    except Exception as e:
+    except urllib.error.URLError as e:
         logger.exception("WA error: %s", e)
         return {"ok": False, "error": str(e)}
 

--- a/tests/test_meta_webhook_handler.py
+++ b/tests/test_meta_webhook_handler.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+
+# Ensure environment variable needed by module is set before import
+os.environ.setdefault("DDB_TABLE", "dummy")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+# Ensure project and app roots on path for imports
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "app"))
+
+from app.runtime import meta_webhook_handler as mwh  # noqa: E402
+
+
+def _client_error(op_name: str) -> ClientError:
+    return ClientError({"Error": {"Code": "Boom", "Message": "boom"}}, op_name)
+
+
+def test_mark_confirmed_query_failure(monkeypatch, caplog):
+    def fake_query(**kwargs):
+        raise _client_error("Query")
+
+    monkeypatch.setattr(mwh.TABLE, "query", fake_query)
+
+    with caplog.at_level("ERROR"):
+        ok, appt = mwh._mark_confirmed_and_cancel("+5939")
+
+    assert (ok, appt) == (False, None)
+    assert "Boom" in caplog.text
+
+
+def test_mark_confirmed_update_failure(monkeypatch, caplog):
+    def fake_query(**kwargs):
+        return {
+            "Items": [
+                {
+                    "pk": "PK",
+                    "sk": "SK",
+                    "r2_schedule_name": "R2",
+                    "esc_schedule_name": "ESC",
+                }
+            ]
+        }
+
+    def fake_update_item(**kwargs):
+        raise _client_error("UpdateItem")
+
+    deleted = []
+
+    def fake_delete_schedule(Name):
+        deleted.append(Name)
+
+    monkeypatch.setattr(mwh.TABLE, "query", fake_query)
+    monkeypatch.setattr(mwh.TABLE, "update_item", fake_update_item)
+    monkeypatch.setattr(mwh.scheduler, "delete_schedule", fake_delete_schedule)
+
+    with caplog.at_level("ERROR"):
+        ok, appt = mwh._mark_confirmed_and_cancel("+5939")
+
+    assert ok is True
+    assert appt["pk"] == "PK"
+    assert set(deleted) == {"R2", "ESC"}
+    assert "Boom" in caplog.text


### PR DESCRIPTION
## Summary
- replace broad exception handlers with specific ValueError, URLError, and ClientError checks
- log AWS ClientError response details
- add tests simulating DynamoDB failures

## Testing
- `ruff check --fix app/runtime/reminder_scheduler.py app/tools/whatsapp_owner.py app/runtime/meta_webhook_handler.py tests/test_meta_webhook_handler.py`
- `black app/runtime/reminder_scheduler.py app/tools/whatsapp_owner.py app/runtime/meta_webhook_handler.py tests/test_meta_webhook_handler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9fd1fe348322a7354b48dcd1f819